### PR TITLE
Update Kubernetes labels to align with AWS resource tags

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -5,10 +5,10 @@
 - `app` - value should contain the name of the application. Should be applied
   to every Kubernetes resource associated with an application. This should be
   also used as replicas selector. E.g. `app=kvm-operator`.
-- `giantswarm.io/cluster-id` - value should contain guest cluster ID which this
-  object is part of. E.g. `giantswarm.io/cluster-id=eggs2`.
 - `giantswarm.io/customer-id` - value should contain guest cluster's customer
   ID. `giantswarm.io/customer-id=track-hunter`.
+- `giantswarm.io/cluster` - value should contain guest cluster ID which this
+  object is part of. E.g. `giantswarm.io/cluster=eggs2`.
 - `giantswarm.io/managed-by` - value should contain repository name of the
   operator managing the object. E.g. `giantswarm.io/managed-by=kvm-operator`.
 

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -5,10 +5,11 @@
 - `app` - value should contain the name of the application. Should be applied
   to every Kubernetes resource associated with an application. This should be
   also used as replicas selector. E.g. `app=kvm-operator`.
-- `giantswarm.io/customer-id` - value should contain guest cluster's customer
-  ID. `giantswarm.io/customer-id=track-hunter`.
 - `giantswarm.io/cluster` - value should contain guest cluster ID which this
   object is part of. E.g. `giantswarm.io/cluster=eggs2`.
+- `giantswarm.io/organization` - value should contain guest cluster's
+organization ID as displayed in the front-end
+`giantswarm.io/organization=track-hunter`.
 - `giantswarm.io/managed-by` - value should contain repository name of the
   operator managing the object. E.g. `giantswarm.io/managed-by=kvm-operator`.
 


### PR DESCRIPTION
I'm proposing we rename `giantswarm.io/cluster-id` to `giantswarm.io/cluster` to align with Kubernetes cloud provider tags.

e.g. `kubernetes.io/cluster/eggs2` Note: they include the cluster ID in the tag so shared resources can be tagged with multiple clusters. I don't think we need to support that.

Also proposed the rename from customer to organization. We should also rename in the CRDs.
https://github.com/giantswarm/giantswarm/issues/2383#issuecomment-369573331 

I can add a section on cloud provider tagging if that is useful. WDYT?
