### PR TITLE
Add missing 'Error' suffix to timeout error

### DIFF
--- a/go/general_style_guide.md
+++ b/go/general_style_guide.md
@@ -80,11 +80,11 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var initializationTimeout = microerror.New("initialization timeout")
+var initializationTimeoutError = microerror.New("initialization timeout")
 
 // IsInitializationTimeout asserts initializationTimeoutError.
 func IsTPRInitTimeout(err error) bool {
-	return microerror.Cause(err) == initializationTimeout
+	return microerror.Cause(err) == initializationTimeoutError
 }
 ```
 


### PR DESCRIPTION
Just noticed that error variable is actually missing `Error` suffix that I understand to be part of this defined style.