### PR TITLE
go: add logs before returns

### DIFF
--- a/go/log_messages.md
+++ b/go/log_messages.md
@@ -39,6 +39,9 @@ var systemFact string
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	} else if err != nil {
+		// Not found log in error. Note it doesn't log the error on
+                // purpose. this should be done by the caller.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find system fact")
 		return microerror.Mask(err)
 	}
 
@@ -77,6 +80,9 @@ var err error
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	} else if err != nil {
+                // Did not ensure log. Note it doesn't log the error on
+                // purpose. this should be done by the caller.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not ensure [deletion of] managed resource")
 		return microerror.Mask(err)
 	}
 
@@ -84,6 +90,9 @@ var err error
 	if IsDeletionInProgress(err) {
 		// Fall trough.
 	} else if err != nil {
+                // Did not ensure log. Note it doesn't log the error on
+                // purpose. this should be done by the caller.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not ensure [deletion of] managed resource")
 		return microerror.Mask(err)
 	}
 

--- a/go/log_messages.md
+++ b/go/log_messages.md
@@ -40,7 +40,7 @@ var systemFact string
 		return nil
 	} else if err != nil {
 		// Not found log in error. Note it doesn't log the error on
-                // purpose. this should be done by the caller.
+		// purpose. this should be done by the caller.
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find system fact")
 		return microerror.Mask(err)
 	}
@@ -80,8 +80,8 @@ var err error
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	} else if err != nil {
-                // Did not ensure log. Note it doesn't log the error on
-                // purpose. this should be done by the caller.
+		// Did not ensure log. Note it doesn't log the error on
+		// purpose. this should be done by the caller.
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not ensure [deletion of] managed resource")
 		return microerror.Mask(err)
 	}
@@ -90,8 +90,8 @@ var err error
 	if IsDeletionInProgress(err) {
 		// Fall trough.
 	} else if err != nil {
-                // Did not ensure log. Note it doesn't log the error on
-                // purpose. this should be done by the caller.
+		// Did not ensure log. Note it doesn't log the error on
+		// purpose. this should be done by the caller.
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not ensure [deletion of] managed resource")
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
I feel like this is useful. It allows to detect what was not
accomplished before returning the error. Proper error logging should be
done as it was. This will align logs for canceling reconciliation due to
handled reasons and due to error.