### PR TITLE
fix typo in golang code example

### DIFF
--- a/go/variable_names.md
+++ b/go/variable_names.md
@@ -14,7 +14,7 @@ variable named `cc`.
 ```go
 cc, err := controllercontext.FromContext(ctx)
 if err != nil {
-	creturn nil, microerror.Mask(err)
+	return nil, microerror.Mask(err)
 }
 ```
 


### PR DESCRIPTION
looks like return also got a extra `c` which should be removed ;) 