### PR TITLE
Add annotation and label for MachineDeployment details

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -10,7 +10,8 @@ This page defines common annotations and labels we set in Kubernetes objects.
   of Kubernetes resources, their functionality and relationships.
 - `machine-deployment.giantswarm.io/subnet` - value contains a subnet CIDR that
   has been allocated for the given node pool / MachineDeployment object that
-  has this annotation.
+  has this annotation. E.g.
+  `machine-deployment.giantswarm.io/subnet=10.102.31.0/24`.
 
 ## Common Labels
 
@@ -61,6 +62,25 @@ This page defines common annotations and labels we set in Kubernetes objects.
 - `giantswarm.io/managed-by`
 - `OPERATOR.giantswarm.io/version`
 - `release.giantswarm.io/version`
+
+
+### Annotations and Labels Set In Cluster API Custom Resource Objects
+
+#### Cluster
+
+##### Annotations
+
+##### Labels
+
+#### MachineDeployment
+
+##### Annotations
+
+- `machine-deployment.giantswarm.io/subnet`
+
+##### Labels
+
+- `giantswarm.io/machine-deployment`
 
 ### Labels Set In Nodes
 

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -8,9 +8,9 @@ This page defines common annotations and labels we set in Kubernetes objects.
   location. For now this should be in our `giantswarm/giantswarm` repository in
   which we crosslink all pages to create a reasonable documentation of all kinds
   of Kubernetes resources, their functionality and relationships.
-- `machine-deployment.giantswarm.io/subnet` - value should contain a subnet
-  CIDR that has been allocated for the given node pool / MachineDeployment
-  object that has this annotation.
+- `machine-deployment.giantswarm.io/subnet` - value contains a subnet CIDR that
+  has been allocated for the given node pool / MachineDeployment object that
+  has this annotation.
 
 ## Common Labels
 

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -8,6 +8,9 @@ This page defines common annotations and labels we set in Kubernetes objects.
   location. For now this should be in our `giantswarm/giantswarm` repository in
   which we crosslink all pages to create a reasonable documentation of all kinds
   of Kubernetes resources, their functionality and relationships.
+- `machine-deployment.giantswarm.io/subnet` - value should contain a subnet
+  CIDR that has been allocated for the given node pool / MachineDeployment
+  object that has this annotation.
 
 ## Common Labels
 
@@ -20,6 +23,9 @@ This page defines common annotations and labels we set in Kubernetes objects.
   Secrets and CertConfigs.
 - `giantswarm.io/cluster` - value should contain tenant cluster ID which this
   object is part of. E.g. `giantswarm.io/cluster=eggs2`.
+- `giantswarm.io/machine-deployment` - value should contain tenant cluster node
+  pool ID (i.e. the machine deployment ID) which this object is part of. E.g.
+  `giantswarm.io/machine-deployment=al9qy`.
 - `giantswarm.io/managed-by` - value should contain repository name of the
   operator managing the object. E.g. `giantswarm.io/managed-by=kvm-operator`.
 - `giantswarm.io/organization` - value should contain tenant cluster's


### PR DESCRIPTION
Node Pool ID and allocated subnet are marked on MachineDeployment object as
label and annotation correspondingly.