### PR TITLE
suggest improvements for cloud formation stack naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - [Control Plane](glossary/control_plane.md)
 - [Installation](glossary/installation.md)
 - [Tenant Cluster Control Plane](glossary/tenant_cluster_control_plane.md)
-- [Tenant Cluster Data Plane](glossary/tenant_cluster_data_plane.md)
+- [Tenant Cluster Node Pool](glossary/tenant_cluster_node_pool.md)
 - [Tenant Cluster](glossary/tenant_cluster.md)
 
 

--- a/glossary/tenant_cluster_data_plane.md
+++ b/glossary/tenant_cluster_data_plane.md
@@ -1,4 +1,0 @@
-# Tenant Cluster Data Plane
-
-Short `TCDP`. The Cloud Formation Stack created for each tenant cluster where we
-manage dedicated node pools.

--- a/glossary/tenant_cluster_node_pool.md
+++ b/glossary/tenant_cluster_node_pool.md
@@ -1,0 +1,4 @@
+# Tenant Cluster Node Pool
+
+Short `TCNP`. The Cloud Formation Stack created for each tenant cluster where we
+manage dedicated node pools.


### PR DESCRIPTION
In scope of the Node Pools story we rename a couple of things. So for instance the the CF stacks. Tuomas brought up how the new CF stack should be called and it would be good to have a reasonable naming scheme somehow. Right now we have this. 

```
CPI - Control Plane Initializer
CPF - Control Plane Finalizer
```

```
TCCP - Tenant Cluster Control Plane
TCDP - Tenant Cluster Data Plane
```

How should this be named? In this PR I made a suggestion on which your feedback is required. See also https://github.com/giantswarm/aws-operator/pull/1725#discussion_r300400240.