### PR TITLE
Go: Initial documentation about interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 - [General Style Guide](go/general_style_guide.md)
 - [Idempotency Conventions](go/idempotency_conventions.md)
 - [Imports](go/imports.md)
-- [Interfaces](go/interface_spec.md)
+- [Interface Spec](go/interface_spec.md)
 - [Log Messages](go/log_messages.md)
 - [Panic](go/panic.md)
 - [Struct Initialization](go/struct_initialization.md)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [General Style Guide](go/general_style_guide.md)
 - [Idempotency Conventions](go/idempotency_conventions.md)
 - [Imports](go/imports.md)
+- [Interfaces](go/interface_spec.md)
 - [Log Messages](go/log_messages.md)
 - [Panic](go/panic.md)
 - [Struct Initialization](go/struct_initialization.md)

--- a/go/interface_spec.md
+++ b/go/interface_spec.md
@@ -1,4 +1,4 @@
-# Interfaces
+# Interface Spec
 
 When providing an interface for a package, it is convention to do this in a `spec.go` file. 
 

--- a/go/interface_spec.md
+++ b/go/interface_spec.md
@@ -1,0 +1,11 @@
+# Interfaces
+
+When providing an interface for a package, it is convention to do this in a `spec.go` file. 
+
+Interfaces follow a naming convention of ending in _'er'_ to describe the behaviour. A `write` package, for example, should fulfil a `Writer` interface. A `scrape` package, should fulfil a `Scraper` interface.
+
+Interfaces are best designed small and simple.
+
+>Well designed interfaces are more likely to be small interfaces; the prevailing idiom is an interface contains only a single method. It follows logically that small interfaces lead to simple implementations, because it is hard to do otherwise. Which leads to packages comprised of simple implementations connected by common behaviour. - _Dave Cheney_
+
+One of the most concrete examples of a well defined interface is the `io.Writer`. A simple, but wildly powerful and implemented interface.

--- a/go/interface_spec.md
+++ b/go/interface_spec.md
@@ -2,7 +2,7 @@
 
 When providing an interface for a package, it is convention to do this in a `spec.go` file. 
 
-Interfaces follow a naming convention of ending in _'er'_ to describe the behaviour. A `write` package, for example, should fulfil a `Writer` interface. A `scrape` package, should fulfil a `Scraper` interface.
+Interfaces follow a naming convention of being ‘agent noun suffixes’; meaning they’ll end in either `or`, `er` to describe the behaviour. For example, a `write` package, should fulfil a `Writer` interface. A `collect` package, should fulfil a `Collector` interface.
 
 Interfaces are best designed small and simple.
 


### PR DESCRIPTION
Simple documentation on how interfaces in Go should be:

- Located to a `spec.go` file for the package
- Named
- Simpler the better