### PR TITLE
Document the catalog-type label.

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -66,6 +66,19 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 ### Annotations and Labels Set In Cluster API Custom Resource Objects
 
+#### App Catalog
+
+##### Labels
+
+- `application.giantswarm.io/catalog-type`
+  Describes the type of catalog that this AppCatalog CR represents.
+  This label helps our UI determine how to show this app catalog.
+
+  - `internal` - Will not show up in our UIs at all.
+  - `managed` - Will gain a 'managed' banner, helping it stand out from other catalogs.
+  - `incubator` - Will show some expectation management message before installing an app from this catalog, that it is still a work in progress, but expected to at least install and somewhat work.
+  - `community` - Will show a more strongly worded expectation management message, indicating that  apps from this catalog will most likely not work without some adjustments.
+
 #### Cluster
 
 ##### Annotations
@@ -100,7 +113,7 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 #### Control Plane
 
-#### Tenant Cluster 
+#### Tenant Cluster
 
 - `app`
 - `giantswarm.io/service-type`


### PR DESCRIPTION
This documents the `application.giantswram.io/catalog-type` label which all `AppCatalog` CR's are expected to have from now on.

ping @JosephSalisbury and anyone else creating Control Plane catalogs, please include this new label and set it to `internal`, then Happa will know not to show it in the UI. (To be implemented)

I think in general I will make it so that Happa does not show any catalog when this value is empty. but we can discuss that in a soon to come Happa PR.

Related to: https://github.com/giantswarm/giantswarm/issues/6616
