### PR TITLE
Add guidelines for templating images in helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 ## Helm Charts
 
 - [Formatting Guidelines](helm/formatting_guidelines.md)
+- [Image Templating](helm/image_templating.md)
 
 
 

--- a/helm/image_templating.md
+++ b/helm/image_templating.md
@@ -1,0 +1,17 @@
+# Helm Chart Image Templating
+
+## Templating
+
+When templating container images in charts `values.yaml` should be structured
+like this. This allows us to override `image.registry` in some control planes
+e.g. AWS China.
+
+
+```yaml
+image:
+  registry: quay.io
+  name: giantswarm/kube-state-metrics
+  tag: v1.8.0
+```
+
+


### PR DESCRIPTION
Prepares us for using App Catalog and reducing some of the image pulling pain we see in AWS China.