### PR TITLE
go: improve example for unit tests

### DIFF
--- a/go/unit_tests.md
+++ b/go/unit_tests.md
@@ -123,6 +123,8 @@ func Test_ClusterID(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
 			clusterID, err := ClusterID(tc.inputObj)
 
 			switch {


### PR DESCRIPTION
It should print the name only for failed tests (unless -v flag is used).