### PR TITLE
Remove glossary from fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,6 @@
 
 
 
-## Glossary
-
-- [Control Plane Finalizer](glossary/control_plane_finalizer.md)
-- [Control Plane Initializer](glossary/control_plane_initializer.md)
-- [Control Plane](glossary/control_plane.md)
-- [Installation](glossary/installation.md)
-- [Special Working Hours](glossary/special_working_hours.md)
-- [Tenant Cluster Control Plane](glossary/tenant_cluster_control_plane.md)
-- [Tenant Cluster Node Pool](glossary/tenant_cluster_node_pool.md)
-- [Tenant Cluster](glossary/tenant_cluster.md)
-
-
-
 ## Go
 
 - [Context](go/context.md)

--- a/glossary/control_plane.md
+++ b/glossary/control_plane.md
@@ -1,8 +1,0 @@
-# Control Plane
-
-Short `CP`. The Kubernetes running Giant Swarm specific management components
-essential for the [Installation].
-
-
-
-[Installation]: installation.md

--- a/glossary/control_plane_finalizer.md
+++ b/glossary/control_plane_finalizer.md
@@ -1,4 +1,0 @@
-# Control Plane Finalizer
-
-Short `CPF`. The Cloud Formation Stack created for each tenant cluster where we
-manage record sets and routing tables.

--- a/glossary/control_plane_initializer.md
+++ b/glossary/control_plane_initializer.md
@@ -1,4 +1,0 @@
-# Control Plane Initializer
-
-Short `CPI`. The Cloud Formation Stack created for each tenant cluster where we
-manage VPC Peering Connections.

--- a/glossary/installation.md
+++ b/glossary/installation.md
@@ -1,4 +1,0 @@
-# Installation
-
-The overall environment managed for a customer. Includes eventual Cloud Provider
-specific accounts.

--- a/glossary/special_working_hours.md
+++ b/glossary/special_working_hours.md
@@ -1,5 +1,0 @@
-# Special Working Hours
-
-Short `SWH`. Time allocated for specific SIG work. Usually one hour bi-weekly.
-People get together and work on what they are interested in, within the scope of
-the particular SIG.

--- a/glossary/tenant_cluster.md
+++ b/glossary/tenant_cluster.md
@@ -1,8 +1,0 @@
-# Tenant Cluster
-
-Short `TC`. The Kubernetes running Customer specific workloads. Managed by some
-[Control Plane].
-
-
-
-[Control Plane]: control_plane.md

--- a/glossary/tenant_cluster_control_plane.md
+++ b/glossary/tenant_cluster_control_plane.md
@@ -1,4 +1,0 @@
-# Tenant Cluster Control Plane
-
-Short `TCCP`. The Cloud Formation Stack created for each tenant cluster where we
-manage service load balancers and master instances.

--- a/glossary/tenant_cluster_node_pool.md
+++ b/glossary/tenant_cluster_node_pool.md
@@ -1,4 +1,0 @@
-# Tenant Cluster Node Pool
-
-Short `TCNP`. The Cloud Formation Stack created for each tenant cluster where we
-manage dedicated node pools.


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/7762

Glossary now exists at https://github.com/giantswarm/giantswarm/tree/master/glossary. All terms here have been moved.