### PR TITLE
Add annotation for restart purposes

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -8,6 +8,9 @@ This page defines common annotations and labels we set in Kubernetes objects.
   location. For now this should be in our `giantswarm/giantswarm` repository in
   which we crosslink all pages to create a reasonable documentation of all kinds
   of Kubernetes resources, their functionality and relationships.
+- `giantswarm.io/restart` - this annotation is meant to be used for DaemonSet,
+  Deployment and StatefulSet restarts. The value can be arbitrary string that
+  works for given reconciliation purposes.
 - `machine-deployment.giantswarm.io/subnet` - value contains a subnet CIDR that
   has been allocated for the given node pool / MachineDeployment object that
   has this annotation. E.g.


### PR DESCRIPTION
Add generic restart annotation that can be used e.g. to issue rolling restart
of DamonSets, Deployments and StatefulSets.

`kubectl` implements rolling restart of deployments by setting `kubectl.kubernetes.io/restartedAt` annotation (see [objectrestarter](https://github.com/kubernetes/kubectl/blob/release-1.16/pkg/polymorphichelpers/objectrestarter.go#L32)).

Initial use-case for this is in `azure-operator` to gracefully move workload from old nodes to new nodes during upgrade.