### PR TITLE
Suggest CircleCI best practice: step documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 - [Naming Resources](azure/naming_resources.md)
 
+## CircleCI
 
+- [All CircleCI best practices](circleci/)
 
 ## Docker
 

--- a/github/circleci/README.md
+++ b/github/circleci/README.md
@@ -1,0 +1,21 @@
+# CircleCI best practices
+
+## Making steps self-explanatory
+
+CircleCI offers a way to make a step in a CI config or org self-explanatory. We SHOULD always use this to make the config more self-explanatory.
+
+### Don't
+
+```yaml
+  steps:
+    - run: [ -z ${CIRCLE_TAG} ] && echo -n 'giantswarm-operations-platform-test-catalog' > .app_catalog_name || echo -n 'giantswarm-operations-platform-catalog' > .app_catalog_name
+```
+
+### Do
+
+```yaml
+  steps:
+    - run:
+      name: Set target catalog name in temp file
+      command: [ -z ${CIRCLE_TAG} ] && echo -n 'giantswarm-operations-platform-test-catalog' > .app_catalog_name || echo -n 'giantswarm-operations-platform-catalog' > .app_catalog_name
+```

--- a/github/circleci/README.md
+++ b/github/circleci/README.md
@@ -16,6 +16,6 @@ CircleCI offers a way to make a step in a CI config or org self-explanatory. We 
 ```yaml
   steps:
     - run:
-      name: Set target catalog name in temp file
-      command: [ -z ${CIRCLE_TAG} ] && echo -n 'giantswarm-operations-platform-test-catalog' > .app_catalog_name || echo -n 'giantswarm-operations-platform-catalog' > .app_catalog_name
+        name: Set target catalog name in temp file
+        command: [ -z ${CIRCLE_TAG} ] && echo -n 'giantswarm-operations-platform-test-catalog' > .app_catalog_name || echo -n 'giantswarm-operations-platform-catalog' > .app_catalog_name
 ```

--- a/github/circleci/README.md
+++ b/github/circleci/README.md
@@ -2,7 +2,7 @@
 
 ## Making steps self-explanatory
 
-CircleCI offers a way to make a step in a CI config or org self-explanatory. We SHOULD always use this to make the config more self-explanatory.
+Always set the `name` of your steps to something that explains what it does.
 
 ### Don't
 


### PR DESCRIPTION
Dear SIG releng, with this PR I propose to make CircleCI steps more self-explanatory.

Here is an example of some nicely documented steps, as suggested in the text:

![image](https://user-images.githubusercontent.com/273727/72712653-c1f7bf80-3b6b-11ea-9282-9f5f77c4a887.png)

And here is an example of what happens if steps are not documented via the `name` field:

![image](https://user-images.githubusercontent.com/273727/72712703-d9cf4380-3b6b-11ea-99a2-e4ad998d5920.png)

This is especially important to me, as these automations have to be understood by many people, but not frequently, so there are many people who don't know these steps by heart and would benefit from better readability and explanation, in case something goes wrong.