### PR TITLE
Add note excluding orbs for CircleCI recommendation

### DIFF
--- a/circleci/all-circleci-best-practices.md
+++ b/circleci/all-circleci-best-practices.md
@@ -2,7 +2,7 @@
 
 ## Making steps self-explanatory
 
-Always set the `name` of your steps to something that explains what it does.
+Always set the `name` of your steps to something that explains what it does. Note: This does not work for orbs as CircleCI does not allow a `name` key for elements in the `steps` array.
 
 ### Don't
 


### PR DESCRIPTION
I could not find the official CircleCI documentation on this, but it seems in orbs, CircleCI does not allow a `name` key in the `steps` element. (See [giantswarm/architect-orb#58](https://github.com/giantswarm/architect-orb/pull/58#pullrequestreview-354254513))