### PR TITLE
Switch from ghodss/yaml to sigs.k8s.io/yaml

### DIFF
--- a/go/yaml_marshalling.md
+++ b/go/yaml_marshalling.md
@@ -1,12 +1,12 @@
 # YAML Marshalling
 
 There are multiple options to marshal yaml in Go but there is no built-in one.
-We decided to use https://github.com/ghodss/yaml library for that purpose.
+We decided to use the [sigs.k8s.io/yaml](https://github.com/kubernetes/kubernetes/tree/master/vendor/sigs.k8s.io/yaml) library for that purpose.
 
 **NOTE:** The `!!binary` YAML tag does not work with this library. See
-https://github.com/ghodss/yaml#caveats.
+https://github.com/kubernetes/kubernetes/tree/master/vendor/sigs.k8s.io/yaml#caveats.
 
-From https://godoc.org/github.com/ghodss/yaml:
+From https://github.com/kubernetes/kubernetes/tree/master/vendor/sigs.k8s.io/yaml#introduction:
 
 > In short, this package first converts YAML to JSON using go-yaml and then
 > uses json.Marshal and json.Unmarshal to convert to or from the struct. This
@@ -23,10 +23,10 @@ Example:
 
 ```go
 type A struct {
-	FeildA string `json:"fieldA"`                // GOOD
+	FieldA string `json:"fieldA"`                // GOOD
 }
 
 type B struct {
-	FeildB string `json:"fieldB" yaml:"fieldB"`  // BAD
+	FieldB string `json:"fieldB" yaml:"fieldB"`  // BAD
 }
 ```


### PR DESCRIPTION
Since most of our YAML marshalling is related to Kubernetes which uses `sigs.k8s.io/yaml` and there are apparently some issues with the `ghodss/yaml` library, I'm updating the go YAML recommendation to use `sigs.k8s.io/yaml`.