### PR TITLE
kubernetes: Integrate k8s common labels

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -56,18 +56,15 @@ This page defines common annotations and labels we set in Kubernetes objects.
   This together with `app.kubernetes.io/name` should be used as replicas
   selector, e.g.
   `app.kubernetes.io/name=kvm-operator,app.kubernetes.io/instance=kvm-operator-1.0.0`.
-- `app.kubernetes.io/version` and other common labels (see
-  [here][helm-labels] and [here][k8s-common-labels]) - are informational,
-  applied to all objects in a chart that installs an app or operator and so
-  they indicate the source and instance of that app/operator; value of
-  `.../version` should be the app/operator version as defined in `project.go`
-  and matching `appVersion` in `Chart.yaml`, e.g.
-  `app.kubernetes.io/version=1.0.0`.
-- `app.giantswarm.io/branch` - (informational) branch from which the instance
-  of the app/operator that this object is part of was built from.
-- `app.giantswarm.io/commit` - (informational) ID (git SHA) of the commit from
-  which the instance of the app/operator that this object is part of was built
-  from.
+- informational labels, applied to all objects in a chart that installs an app
+  or operator and so they indicate its source and instance:
+  - `app.kubernetes.io/version` - value should be the app/operator version as
+    defined in `project.go` and matching `appVersion` in `Chart.yaml`, e.g.
+    `app.kubernetes.io/version=1.0.0`.
+  - `app.giantswarm.io/branch` - branch from which the instance of the
+    app/operator that this object is part of was built from.
+  - `app.giantswarm.io/commit` - ID (git SHA) of the commit from which the
+    instance of the app/operator that this object is part of was built from.
 - `giantswarm.io/provider` - value should be the installation's provider, e.g.
   `kvm`, `aws`, or `azure`.
 

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -39,16 +39,16 @@ This page defines common annotations and labels we set in Kubernetes objects.
 - `release.giantswarm.io/version` - value should be Giant Swarm release
   version, e.g. `release.giantswarm.io/version=2.3.0`.
 - `OPERATOR.giantswarm.io/version` - value should be the version of the
-  operator reconciling the object, as defined in `project.go` and matching
+  given operator reconciling the object, as defined in its `project.go` and
   `appVersion` in `Chart.yaml`, e.g.
   `kvm-operator.giantswarm.io/version=1.0.0`. It is used by the given operator
   to recognize which object it should reconcile (i.e. to only reconcile objects
-  matching its own version). When set on Node objects it is used to set that
-  information in the status with the statusresource. This is different from
-  release version and can be the same in multiple releases. Its value may be
-  equal to that of `app.kubernetes.io/version` but it has a different purpose
-  and since there could be multiple operators reconciling one object there
-  could be multiple per-operator labels on one object.
+  matching its own version, which is exposed as `app.kubernetes.io/version` on
+  the operator's own component resources like `Deployment`). When set on Node
+  objects it is used to set that information in the status with the
+  statusresource. This is different from release version and can be the same in
+  multiple releases. Since there could be multiple operators reconciling one
+  object there could be multiple per-operator labels on one object.
 - `helm.sh/chart` - value should contain a chart name and version, see
   [Helm chart labels best practices][helm-labels]
 - `app.kubernetes.io/name` - the name of the application; should be applied to
@@ -63,7 +63,12 @@ This page defines common annotations and labels we set in Kubernetes objects.
   or operator and so they indicate its source and instance:
   - `app.kubernetes.io/version` - value should be the app/operator version as
     defined in `project.go` and matching `appVersion` in `Chart.yaml`, e.g.
-    `app.kubernetes.io/version=1.0.0`.
+    `app.kubernetes.io/version=1.0.0`. In case of our operators there should be
+    only a single instance with a given version running on a cluster as this
+    also indicates this operator reconciles objects labeled with
+    `OPERATOR.giantswarm.io/version` with the same value, and there should be
+    only one **version** of an operator reconciling a single object. This is
+    enforced by GateKeeper on our clusters.
   - `app.giantswarm.io/branch` - branch from which the instance of the
     app/operator that this object is part of was built from.
   - `app.giantswarm.io/commit` - ID (git SHA) of the commit from which the

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -254,7 +254,7 @@ with labels:
 <details>
 <summary>EXAMPLE</summary>
 <p>
-For example, given snippet from `templates/deployment.yaml` in _aws-operator_:
+For example, this snippet from <code>templates/deployment.yaml</code> in <em>aws-operator</em>:
 
 ``` yaml
 apiVersion: apps/v1

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -182,13 +182,13 @@ querying by shared tooling.
 Labels related to a higher-level virtual concept of an _app_, i.e. a bunch of
 components usually installed by one or more Helm charts.
 
-- `helm.sh/chart`
 - `app.kubernetes.io/name`
 - `app.kubernetes.io/instance`
-- `app.kubernetes.io/version`
-- `app.kubernetes.io/managed-by`
 - `app.giantswarm.io/branch`
 - `app.giantswarm.io/commit`
+- `app.kubernetes.io/managed-by`
+- `app.kubernetes.io/version`
+- `helm.sh/chart`
 
 To set those labels without having to repeat their definition in multiple
 places we use a template helper based on that in [chart template][helm-def-tpl]
@@ -220,12 +220,12 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "aws-operator.labels" -}}
-helm.sh/chart: {{ include "aws-operator.chart" . | quote }}
 {{ include "aws-operator.selectorLabels" . }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ include "aws-operator.chart" . | quote }}
 {{- end -}}
 
 {{/*
@@ -291,14 +291,13 @@ metadata:
   name: aws-operator-8-2-1-dcff541
   namespace: giantswarm
   labels:
-    helm.sh/chart: "aws-operator-8.2.1-dcff5413bbd51d2a57ce69fead20c2eb9cb35d47"
-    app: "aws-operator"
     app.kubernetes.io/name: "aws-operator"
     app.kubernetes.io/instance: "aws-operator-8.2.1-dcff541"
     app.giantswarm.io/branch: "voo-ensure-labels"
-    app.giantswarm.io/commit: "dcff5413bbd51d2a57ce69fead20c2eb9cb35d47"
-    app.kubernetes.io/version: "8.2.2-dev"
+    app.giantswarm.io/commit: "5b8a2f2e457e7a0f95084b32a43ce88959fd2552"
     app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "8.2.2-dev"
+    helm.sh/chart: "aws-operator-8.2.1-5b8a2f2e457e7a0f95084b32a43ce88959fd2552"
 spec:
   replicas: 1
   revisionHistoryLimit: 3

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -15,10 +15,6 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 ## Common Labels
 
-- `app` - value should contain the name of the application. Should be applied
-  to every Kubernetes resource associated with an application. This together with `version`
-  label should also be used as replicas selector. E.g. `app=kvm-operator,version=1.0.0`. Exceptions can
-  be made to accomodate for adherence to existing selectors upstream.
 - `giantswarm.io/certificate` - value should contain certificate name as
   defined in github.com/giantswarm/certs repo. This is used in certificate
   Secrets and CertConfigs.
@@ -74,10 +70,6 @@ This page defines common annotations and labels we set in Kubernetes objects.
   from.
 - `giantswarm.io/provider` - value should be the installation's provider, e.g.
   `kvm`, `aws`, or `azure`.
-- `version` - value should contain the version of the application.  Should be applied
-  to every Kubernetes resource associated with an application. This together with `app`
-  label should also be used as replicas selector. E.g. `app=kvm-operator,version=1.0.0`. Exceptions can
-  be made to accomodate for adherence to existing selectors upstream.
 
 Also see [Helm chart labels best practices][helm-labels] and
 [common labels recommended in Kubernetes docs][k8s-common-labels] for a set of

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -203,7 +203,7 @@ templates in the chart.
 Contents of `_helpers.tpl` (replace `aws-operator` with the name of your
 app/operator):
 
-``` HTML+Django
+```
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -50,7 +50,7 @@ This page defines common annotations and labels we set in Kubernetes objects.
   [Helm chart labels best practices][helm-labels]
 - `app.kubernetes.io/name` - the name of the application; should be applied to
   every Kubernetes resource associated with that application, i.e. all objects
-  in a chart that installs it.
+  in a chart that installs it. E.g. `app.kubernetes.io/name=kvm-operator`.
 - `app.kubernetes.io/instance` - value should be set to `{{ .Release.Name }}`
   and is meant for differentiating between instances of the same application.
   This together with `app.kubernetes.io/name` should be used as replicas

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -50,16 +50,43 @@ This page defines common annotations and labels we set in Kubernetes objects.
   Its value may be equal to that of `app.kubernetes.io/version` but it has a
   different purpose and since there could be multiple operators reconciling one
   object there could be multiple per-operator labels on one object.
-- `app.giantswarm.io/branch` - (informational) branch from which this
-  instance of the app/operator was built from.
+- `helm.sh/chart` - value should contain a chart name and version, see
+  [Helm chart labels best practices][helm-labels]
+- `app.kubernetes.io/name` - the name of the application; should be applied to
+  every Kubernetes resource associated with that application, i.e. all objects
+  in a chart that installs it.
+- `app.kubernetes.io/instance` - value should be set to `{{ .Release.Name }}`
+  and is meant for differentiating between instances of the same application.
+  This together with `app.kubernetes.io/name` should be used as replicas
+  selector, e.g.
+  `app.kubernetes.io/name=kvm-operator,app.kubernetes.io/instance=kvm-operator-1.0.0`.
+- `app.kubernetes.io/version` and other common labels (see
+  [here][helm-labels] and [here][k8s-common-labels]) - are informational,
+  applied to all objects in a chart that installs an app or operator and so
+  they indicate the source and instance of that app/operator; value of
+  `.../version` should be the app/operator version as defined in `project.go`
+  and matching `appVersion` in `Chart.yaml`, e.g.
+  `app.kubernetes.io/version=1.0.0`.
+- `app.giantswarm.io/branch` - (informational) branch from which the instance
+  of the app/operator that this object is part of was built from.
 - `app.giantswarm.io/commit` - (informational) ID (git SHA) of the commit from
-  which this instance of the app/operator was built from.
+  which the instance of the app/operator that this object is part of was built
+  from.
 - `giantswarm.io/provider` - value should be the installation's provider, e.g.
   `kvm`, `aws`, or `azure`.
 - `version` - value should contain the version of the application.  Should be applied
   to every Kubernetes resource associated with an application. This together with `app`
   label should also be used as replicas selector. E.g. `app=kvm-operator,version=1.0.0`. Exceptions can
   be made to accomodate for adherence to existing selectors upstream.
+
+Also see [Helm chart labels best practices][helm-labels] and
+[common labels recommended in Kubernetes docs][k8s-common-labels] for a set of
+common labels that can be set on all objects to enable visualisation and
+querying by shared tooling.
+
+
+[helm-labels]: https://helm.sh/docs/topics/chart_best_practices/labels/
+[k8s-common-labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 
 ### Labels Set In Custom Resources
 

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -249,11 +249,12 @@ with labels:
 - `aws-operator.chart` - normalised name + version of the chart, i.e. trimmed
   to 63 characters and with `+` signs replaced with `-`
 - `aws-operator.labels` - defines all the labels described above, including the
-  selector labels; usage: `{{- include "aws-operator.labels" . | nindent 4 }}`
-  (adjust indent as required)
+  selector labels;
+  usage: `{{- include "aws-operator.labels" . | nindent INDENT }}`
+  (set `INDENT` to required number of spaces)
 - `aws-operator.selectorLabels` - defines labels to be used in selectors;
-  usage: `{{- include "aws-operator.selectorLabels" . | nindent 6 }}`
-  (adjust indent as required)
+  usage: `{{- include "aws-operator.selectorLabels" . | nindent INDENT }}`
+  (set `INDENT` to required number of spaces)
 
 <details>
 <summary>EXAMPLE</summary>

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -176,7 +176,7 @@ querying by shared tooling.
 
 #### Tenant Cluster
 
-### App Labels
+### Labels Set On Objects Installed By Charts
 
 Labels related to a higher-level virtual concept of an _app_, i.e. a bunch of
 components usually installed by one or more Helm charts.

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -37,15 +37,16 @@ This page defines common annotations and labels we set in Kubernetes objects.
 - `release.giantswarm.io/version` - value should be Giant Swarm release
   version, e.g. `release.giantswarm.io/version=2.3.0`.
 - `OPERATOR.giantswarm.io/version` - value should be the version of the
-  operator as defined in `project.go` and matching `appVersion` in
-  `Chart.yaml`, e.g. `kvm-operator.giantswarm.io/version=1.0.0`. It is used by
-  the given operator to recognize which object it should reconcile (i.e. to
-  only reconcile objects matching its own version). When set on Node objects it
-  is used to set that information in the status with the statusresource. This
-  is different from release version and can be the same in multiple releases.
-  Its value may be equal to that of `app.kubernetes.io/version` but it has a
-  different purpose and since there could be multiple operators reconciling one
-  object there could be multiple per-operator labels on one object.
+  operator reconciling the object, as defined in `project.go` and matching
+  `appVersion` in `Chart.yaml`, e.g.
+  `kvm-operator.giantswarm.io/version=1.0.0`. It is used by the given operator
+  to recognize which object it should reconcile (i.e. to only reconcile objects
+  matching its own version). When set on Node objects it is used to set that
+  information in the status with the statusresource. This is different from
+  release version and can be the same in multiple releases. Its value may be
+  equal to that of `app.kubernetes.io/version` but it has a different purpose
+  and since there could be multiple operators reconciling one object there
+  could be multiple per-operator labels on one object.
 - `helm.sh/chart` - value should contain a chart name and version, see
   [Helm chart labels best practices][helm-labels]
 - `app.kubernetes.io/name` - the name of the application; should be applied to
@@ -188,7 +189,6 @@ components usually installed by one or more Helm charts.
 - `app.kubernetes.io/managed-by`
 - `app.giantswarm.io/branch`
 - `app.giantswarm.io/commit`
-- `OPERATOR.giantswarm.io/version`
 
 ## Finalizers
 

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -15,6 +15,11 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 ## Common Labels
 
+- `app` - value should contain the name of the application. Should be applied
+  to every Kubernetes resource associated with an application. E.g.
+  `app=kvm-operator`. This is softly deprecated and should be replaced with
+  `app.kubernetes.io/name`, it's only kept to avoid breaking existing
+  workflows.
 - `giantswarm.io/certificate` - value should contain certificate name as
   defined in github.com/giantswarm/certs repo. This is used in certificate
   Secrets and CertConfigs.
@@ -182,6 +187,7 @@ querying by shared tooling.
 Labels related to a higher-level virtual concept of an _app_, i.e. a bunch of
 components usually installed by one or more Helm charts.
 
+- `app`
 - `app.kubernetes.io/name`
 - `app.kubernetes.io/instance`
 - `app.giantswarm.io/branch`
@@ -220,6 +226,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "aws-operator.labels" -}}
+app: {{ include "aws-operator.name" . | quote }}
 {{ include "aws-operator.selectorLabels" . }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
@@ -291,6 +298,7 @@ metadata:
   name: aws-operator-8-2-1-dcff541
   namespace: giantswarm
   labels:
+    app: "aws-operator"
     app.kubernetes.io/name: "aws-operator"
     app.kubernetes.io/instance: "aws-operator-8.2.1-dcff541"
     app.giantswarm.io/branch: "voo-ensure-labels"

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -179,6 +179,20 @@ querying by shared tooling.
 
 #### Tenant Cluster
 
+### App Labels
+
+Labels related to a higher-level virtual concept of an _app_, i.e. a bunch of
+components usually installed by one or more Helm charts.
+
+- `helm.sh/chart`
+- `app.kubernetes.io/name`
+- `app.kubernetes.io/instance`
+- `app.kubernetes.io/version`
+- `app.kubernetes.io/managed-by`
+- `app.giantswarm.io/branch`
+- `app.giantswarm.io/commit`
+- `OPERATOR.giantswarm.io/version`
+
 ## Finalizers
 
 - Operatorkit sets a finalizer for objects that are watched by the framework

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -223,8 +223,8 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "aws-operator.labels" -}}
-app: {{ include "aws-operator.name" . | quote }}
 {{ include "aws-operator.selectorLabels" . }}
+app: {{ include "aws-operator.name" . | quote }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -15,11 +15,8 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 ## Common Labels
 
-- `app` - value should contain the name of the application. Should be applied
-  to every Kubernetes resource associated with an application. E.g.
-  `app=kvm-operator`. This is softly deprecated and should be replaced with
-  `app.kubernetes.io/name`, it's only kept to avoid breaking existing
-  workflows.
+- `app` - should be set to the same value as `app.kubernetes.io/name`. It's
+  deprecated and only kept to avoid breaking existing workflows.
 - `giantswarm.io/certificate` - value should contain certificate name as
   defined in github.com/giantswarm/certs repo. This is used in certificate
   Secrets and CertConfigs.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8632

Include common labels advocated in Kubernetes docs, there's some
overlap with our internal ones and after discussing this the consensus
was that it would be better to avoid that and standardise on the well
defined set from Kubernetes/Helm upstream.

Those labels allow us to describe the source and instance of an app so
it's easy to see which installation an object is part of.

Inline description of the main labels specifying what are the expected
values and that they apply to all objects composing an app/operator
they refer to.

Also add this to description of related custom `.../branch` and
`.../commit` labels.