### PR TITLE
Truncate branch label at 63 chars

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -229,7 +229,7 @@ Common labels
 {{- define "labels.common" -}}
 app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
-app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace "/" "-" | quote }}
+app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | replace "/" "-" | trunc 63 | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/fmt/pull/121.

I merged too soon. 🤦‍♂️  We also need to truncate the label at 63 chars.

