### PR TITLE
Add node pool labels

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -39,10 +39,6 @@ This page defines common annotations and labels we set in Kubernetes objects.
   services (i.e. K8s components) or `managed` for Giant Swarm managed services
   (i.e. networking, DNS, monitoring, ingress controller, etc.). Latter would be
   managed by `chart-operator`.
-- `machine-pool.giantswarm.io/subnet`: value should contain the name of the
-  subnet where the tenant cluster node pool is deployed. This name should be
-  equivalent to the tenant cluster node pool ID. E.g.
-  `machine-pool.giantswarm.io/subnet=de19f-1`.
 - `release.giantswarm.io/version` - value should be Giant Swarm release
   version, e.g. `release.giantswarm.io/version=2.3.0`.
 - `OPERATOR.giantswarm.io/version` - value should be the version of the

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -12,6 +12,8 @@ This page defines common annotations and labels we set in Kubernetes objects.
   has been allocated for the given node pool / MachineDeployment object that
   has this annotation. E.g.
   `machine-deployment.giantswarm.io/subnet=10.102.31.0/24`.
+- `machine-pool.giantswarm.io/name` - value contains a human-friendly node pool
+  name set by the customer. It is defined in [`github.com/giantswarm/apiextensions/pkg/annotation` package](https://github.com/giantswarm/apiextensions/blob/master/pkg/annotation/nodepool.go).
 
 ## Common Labels
 
@@ -27,7 +29,8 @@ This page defines common annotations and labels we set in Kubernetes objects.
   `giantswarm.io/machine-deployment=al9qy`.
 - `giantswarm.io/machine-pool` - value should contain tenant cluster node pool
   ID (i.e. the machine pool ID) which this object is part of. E.g.
-  `giantswarm.io/machine-pool=de19f-1`.
+  `giantswarm.io/machine-pool=de19f-1`. It is defined in
+  [`github.com/giantswarm/apiextensions/pkg/label` package](https://github.com/giantswarm/apiextensions/blob/master/pkg/label/id.go).
 - `giantswarm.io/managed-by` - value should contain repository name of the
   operator managing the object. E.g. `giantswarm.io/managed-by=kvm-operator`.
 - `giantswarm.io/organization` - value should contain tenant cluster's

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -25,6 +25,9 @@ This page defines common annotations and labels we set in Kubernetes objects.
 - `giantswarm.io/machine-deployment` - value should contain tenant cluster node
   pool ID (i.e. the machine deployment ID) which this object is part of. E.g.
   `giantswarm.io/machine-deployment=al9qy`.
+- `giantswarm.io/machine-pool` - value should contain tenant cluster node pool
+  ID (i.e. the machine pool ID) which this object is part of. E.g.
+  `giantswarm.io/machine-pool=de19f-1`.
 - `giantswarm.io/managed-by` - value should contain repository name of the
   operator managing the object. E.g. `giantswarm.io/managed-by=kvm-operator`.
 - `giantswarm.io/organization` - value should contain tenant cluster's
@@ -36,6 +39,10 @@ This page defines common annotations and labels we set in Kubernetes objects.
   services (i.e. K8s components) or `managed` for Giant Swarm managed services
   (i.e. networking, DNS, monitoring, ingress controller, etc.). Latter would be
   managed by `chart-operator`.
+- `machine-pool.giantswarm.io/subnet`: value should contain the name of the
+  subnet where the tenant cluster node pool is deployed. This name should be
+  equivalent to the tenant cluster node pool ID. E.g.
+  `machine-pool.giantswarm.io/subnet=de19f-1`.
 - `release.giantswarm.io/version` - value should be Giant Swarm release
   version, e.g. `release.giantswarm.io/version=2.3.0`.
 - `OPERATOR.giantswarm.io/version` - value should be the version of the

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -29,7 +29,7 @@ This page defines common annotations and labels we set in Kubernetes objects.
   `giantswarm.io/machine-deployment=al9qy`.
 - `giantswarm.io/machine-pool` - value should contain tenant cluster node pool
   ID (i.e. the machine pool ID) which this object is part of. E.g.
-  `giantswarm.io/machine-pool=de19f-1`. It is defined in
+  `giantswarm.io/machine-pool=de19f`. It is defined in
   [`github.com/giantswarm/apiextensions/pkg/label` package](https://github.com/giantswarm/apiextensions/blob/master/pkg/label/id.go).
 - `giantswarm.io/managed-by` - value should contain repository name of the
   operator managing the object. E.g. `giantswarm.io/managed-by=kvm-operator`.


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/160

What's in the box:
- `giantswarm.io/machine-pool` - value should contain tenant cluster node pool ID (i.e. the machine pool ID) which this object is part of. E.g. `giantswarm.io/machine-pool=de19f`.
- `machine-pool.giantswarm.io/name`: value contains a human-friendly node pool name set by the customer.
