### PR TITLE
Add labels and annotations used for Cluster and AzureCluster CRs

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -4,6 +4,8 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 ## Common Annotations
 
+- `cluster.giantswarm.io/description` - value contains a human-friendly cluster
+  name set by the customer. It is defined in [`github.com/giantswarm/apiextensions/pkg/annotation` package](https://github.com/giantswarm/apiextensions/blob/master/pkg/annotation/cluster.go).
 - `giantswarm.io/docs` - value should be an URL to a common documentation
   location. For now this should be in our `giantswarm/giantswarm` repository in
   which we crosslink all pages to create a reasonable documentation of all kinds
@@ -132,6 +134,26 @@ querying by shared tooling.
 ##### Annotations
 
 ##### Labels
+
+- `cluster.x-k8s.io/cluster-name`
+- `giantswarm.io/cluster`
+- `giantswarm.io/organization`
+- `OPERATOR.giantswarm.io/version`
+- `release.giantswarm.io/version`
+
+#### AzureCluster
+
+##### Annotations
+
+- `cluster.giantswarm.io/description`
+
+##### Labels
+
+- `cluster.x-k8s.io/cluster-name`
+- `giantswarm.io/cluster`
+- `giantswarm.io/organization`
+- `OPERATOR.giantswarm.io/version`
+- `release.giantswarm.io/version`
 
 #### MachineDeployment
 

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -21,6 +21,9 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 - `app` - should be set to the same value as `app.kubernetes.io/name`. It's
   deprecated and only kept to avoid breaking existing workflows.
+- `cluster.x-k8s.io/cluster-name` - currently set to same value same as
+  `giantswarm.io/cluster`, which should contain tenant cluster ID which this
+  object is part of. E.g. `giantswarm.io/cluster=eggs2`.
 - `giantswarm.io/certificate` - value should contain certificate name as
   defined in github.com/giantswarm/certs repo. This is used in certificate
   Secrets and CertConfigs.

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -21,9 +21,10 @@ This page defines common annotations and labels we set in Kubernetes objects.
 
 - `app` - should be set to the same value as `app.kubernetes.io/name`. It's
   deprecated and only kept to avoid breaking existing workflows.
-- `cluster.x-k8s.io/cluster-name` - currently set to same value same as
-  `giantswarm.io/cluster`, which should contain tenant cluster ID which this
-  object is part of. E.g. `giantswarm.io/cluster=eggs2`.
+- `cluster.x-k8s.io/cluster-name` - currently set to same value as
+  `giantswarm.io/cluster`, which is same as `Meta.Name` field of the CR and it
+  should contain tenant cluster ID which this object is part of. E.g.
+  `giantswarm.io/cluster=eggs2`.
 - `giantswarm.io/certificate` - value should contain certificate name as
   defined in github.com/giantswarm/certs repo. This is used in certificate
   Secrets and CertConfigs.


### PR DESCRIPTION
These are labels and annotations that are currently planned to be used for `Cluster` and `AzureCluster` CRs.

### Note and question about `Cluster` CR labels

`Cluster` CR is used for both Azure and AWS tenant clusters and, if I'm not mistaken, for AWS clusters the `cluster.x-k8s.io/cluster-name` label is not set. Should we keep it that way and clarify the difference in the `fmt` repo, or should we make Azure and AWS consistent here?

Motivation for using upstream Cluster API labels: In azure-operator we started using some utility functions from the upstream CAPI and CAPZ projects, and those are often looking for and using upstream labels. We decided that it would be better to use label definitions from the upstream packages, than to copy them to our projects.