### PR TITLE
Add section about nancy to Go guide

### DIFF
--- a/go/general_style_guide.md
+++ b/go/general_style_guide.md
@@ -78,9 +78,25 @@ A finding from `nancy` might look like:
 
 ```
 
-The best course of action is to update the dependency.
-If the dependency is nested, try using a `replace` directive in `go.mod` to use a safe version.
-If it is not possible to update the dependency for technical or compatibility reasons, you can suppress the finding by adding it to a file named `.nancy-ignore` in the root of your repository.
+For each identified vulnerability:
+
+1. First, try to update the vulnerable dependency. If the dependency is not a _direct_ dependency, try using `go mod graph` to identify which package imports it, and update that instead.
+2. If the vulnerable dependency can't be resolved by updating a direct dependency, add a `replace` directive to your `go.mod` file.
+For example, in the finding above, `gorilla/websocket v1.4.0` is vulnerable, but `v1.4.2` has been fixed.
+This vulnerability can be mitigated by adding the following to the project's `go.mod` ():
+
+ ```go
+ replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
+ ```
+
+3. If the fixed dependency version introduces a breaking change or is otherwise impossible to update, you can suppress the finding temporarily to allow time for the dependency to be updated upstream.
+
+When ignoring a dependency, always include a reasonable expiration date (as a suggestion, within 30 days).
+Never create an ignore rule with no expiration -- every vulnerable dependency should either be updated or removed.
+The suppression is only to unblock development until a patch is released.
+If an update is still not available after the 30 day suppression period, this suggests that one of the components used is not regularly maintained. The dependency should be replaced with an alternative or `require`d by the project directly to ensure it continues to stay up to date.
+
+To suppress a finding, add the name of the vulnerability to a file named `.nancy-ignore` in the root of your repository.
 
 For example, this file would suppress the warning above until October 1st 2020:
 

--- a/go/general_style_guide.md
+++ b/go/general_style_guide.md
@@ -40,6 +40,67 @@ This should be used sparingly to avoid forming a bad habit of simply silencing b
 Details for using all of these methods can be found in the
 [False Positives](https://github.com/golangci/golangci-lint#false-positives) section of the docs.
 
+## Vulnerability and Dependency Management
+
+For keeping dependencies up to date, we use [Dependabot](../github/dependabot), which is documented separately.
+
+While Dependabot helps to keep dependencies fresh, it is still possible for them to be vulnerable.
+For that reason, we also use [`nancy`](https://github.com/sonatype-nexus-community/nancy) to scan a project's dependencies for known vulnerabilities at build time.
+
+A finding from `nancy` might look like:
+
+```shell
+[1/1]	pkg:golang/github.com/gorilla/websocket@1.4.0
+1 known vulnerabilities affecting installed version 
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ CWE-190: Integer Overflow or Wraparound                                                                                                                            ┃
+┣━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ Description        ┃ The software performs a calculation that can produce an integer overflow or                                                                   ┃
+┃                    ┃ wraparound, when the logic assumes that the resulting value will always be                                                                    ┃
+┃                    ┃ larger than the original value. This can introduce other weaknesses when                                                                      ┃
+┃                    ┃ the calculation is used for resource management or execution control.                                                                         ┃
+┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ OSS Index ID       ┃ 5f259e63-3efb-4c47-b593-d175dca716b0                                                                                                          ┃
+┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ CVSS Score         ┃ 7.5/10 (High)                                                                                                                                 ┃
+┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ CVSS Vector        ┃ CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H                                                                                                  ┃
+┣━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ Link for more info ┃ https://ossindex.sonatype.org/vuln/5f259e63-3efb-4c47-b593-d175dca716b0?component-type=golang&component-name=github.com%2Fgorilla%2Fwebsocket ┃
+┗━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Summary                       ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━┫
+┃ Audited Dependencies    ┃ 223 ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━┫
+┃ Vulnerable Dependencies ┃ 1   ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━┛
+
+```
+
+The best course of action is to update the dependency.
+If the dependency is nested, try using a `replace` directive in `go.mod` to use a safe version.
+If it is not possible to update the dependency for technical or compatibility reasons, you can suppress the finding by adding it to a file named `.nancy-ignore` in the root of your repository.
+
+For example, this file would suppress the warning above until October 1st 2020:
+
+```text
+# .nancy-ignore
+
+CWE-190 until=2020-10-01
+```
+
+Often, the vulnerability is referenced by a CVE number instead of a CWE.
+You can suppress specific CVE numbers in the same way:
+
+```text
+# .nancy-ignore
+
+CVE-2020-15114 until=2020-10-01
+```
+
+You can run `nancy` locally by building downloading the binary and running `go list -json -m all | nancy -quiet` from the root of your project.
+
 ## Tooling
 
 You can lint your code straight from the editor

--- a/go/general_style_guide.md
+++ b/go/general_style_guide.md
@@ -99,7 +99,7 @@ You can suppress specific CVE numbers in the same way:
 CVE-2020-15114 until=2020-10-01
 ```
 
-You can run `nancy` locally by building downloading the binary and running `go list -json -m all | nancy -quiet` from the root of your project.
+You can run `nancy` locally by building or downloading the binary and running `go list -json -m all | nancy -quiet` from the root of your project.
 
 ## Tooling
 


### PR DESCRIPTION
Nancy is a vulnerability scanner for Go dependencies. It will be added to `architect-orb` by https://github.com/giantswarm/architect-orb/pull/173

This section includes some info about what to expect and how to work with it