### PR TITLE
azure v5: explain Cluster/MachinePool description annotations

### DIFF
--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -131,6 +131,8 @@ querying by shared tooling.
 
 ##### Annotations
 
+- `cluster.giantswarm.io/description` - A user-friendly cluster description.
+
 ##### Labels
 
 #### MachineDeployment
@@ -142,6 +144,14 @@ querying by shared tooling.
 ##### Labels
 
 - `giantswarm.io/machine-deployment`
+
+#### MachinePool
+
+##### Annotations
+
+- `machine-pool.giantswarm.io/name` - A user-friendly machine pool description.
+
+##### Labels
 
 ### Labels Set In Nodes
 


### PR DESCRIPTION
We use these annotations for setting user-friendly descriptions for clusters and node pools. These are visible in happa/gsctl/kubectl-gs under the key called `name`.