### PR TITLE
Add Helm checksum annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 
 ## Helm Charts
 
+- [Checksum Annotations](helm/checksum_annotations.md)
 - [Formatting Guidelines](helm/formatting_guidelines.md)
 - [Image Templating](helm/image_templating.md)
 

--- a/helm/checksum_annotations.md
+++ b/helm/checksum_annotations.md
@@ -12,7 +12,7 @@ annotations are not needed.
 
 ## Annotations
 
-- The secret annotation is only needed if chart has a templated secret.
+- The secret annotation is only needed if the chart has a templated secret.
 
 ```yaml
 apiVersion: apps/v1

--- a/helm/checksum_annotations.md
+++ b/helm/checksum_annotations.md
@@ -12,7 +12,7 @@ annotations are not needed.
 
 ## Annotations
 
-- The secret annotation is only needed if Chart has a template.
+- The secret annotation is only needed if chart has a templated secret.
 
 ```yaml
 apiVersion: apps/v1

--- a/helm/checksum_annotations.md
+++ b/helm/checksum_annotations.md
@@ -1,0 +1,43 @@
+# Helm Checksum Annotations
+
+## Overview
+
+- We add checksum annotations to our deployments and daemonsets to trigger
+fresh pods when their configmaps or secrets have changed.
+- This reduces how often we need to roll pods which can be disruptive.
+- Changes to other resources like PSP and RBAC are applied without needing to
+roll pods.
+- If the app has auto reload functionality like Nginx Ingress Controller these
+annotations are not needed.
+
+## Annotations
+
+- The secret annotation is only needed if Chart has a template.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        app.giantswarm.io/config-checksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+        app.giantswarm.io/secret-checksum: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum | quote }}
+```
+
+- Our approach is adapted from the [Helm docs](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).
+
+## Previous Approach
+
+- We used to use the Helm release revision number or for Helm 2 the release time.
+- This triggers the rolling of pods more often which can be disruptive.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        releaseRevision: {{ .Release.Revision | quote }}
+```

--- a/kubernetes/annotations_and_labels.md
+++ b/kubernetes/annotations_and_labels.md
@@ -370,7 +370,7 @@ spec:
   template:
     metadata:
       annotations:
-        releasetime: {{ $.Release.Time }}
+        app.giantswarm.io/config-checksum: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "labels.selector" . | nindent 8 }}
     spec:
@@ -406,7 +406,7 @@ spec:
   template:
     metadata:
       annotations:
-        releasetime: 
+        app.giantswarm.io/config-checksum: 86328d7f4f645d74d43e17bb0ff877b0e09a2d4bd9f0fb6eb665a550b1b50320
       labels:
         app.kubernetes.io/name: "aws-operator"
         app.kubernetes.io/instance: "aws-operator-8.2.1-dcff541"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13309

Tnis proposes changing the Helm release revision to checksum annotations as recommended in the Helm docs.
https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

This will reduce the number of rolled pods when updating draughtsman values or if there is a problem with reconciling app CRs.


